### PR TITLE
Bumping Java version: 1.6 --> 1.8

### DIFF
--- a/pangolin-core/pom.xml
+++ b/pangolin-core/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>provided</scope>
-        </dependency>
+        </dependency>              
     </dependencies>
 
 </project>

--- a/pangolin-eclipse-core/META-INF/MANIFEST.MF
+++ b/pangolin-eclipse-core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Pangolin plugin Core
 Bundle-SymbolicName: pt.up.fe.pangolin.eclipse.core;singleton:=true
 Bundle-Version: 0.0.1
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jdt.launching;bundle-version="3.7.0",
  org.eclipse.debug.core;bundle-version="3.8.0",
  org.eclipse.core.runtime;bundle-version="3.9.0",

--- a/pangolin-eclipse-core/META-INF/MANIFEST.MF
+++ b/pangolin-eclipse-core/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Pangolin plugin Core
 Bundle-SymbolicName: pt.up.fe.pangolin.eclipse.core;singleton:=true
 Bundle-Version: 0.0.1
+Automatic-Module-Name: pt.up.fe.pangolin.eclipse.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jdt.launching;bundle-version="3.7.0",
  org.eclipse.debug.core;bundle-version="3.8.0",

--- a/pangolin-eclipse-core/src/main/java/pt/up/fe/pangolin/eclipse/core/launching/VMArgsLaunchConfiguration.java
+++ b/pangolin-eclipse-core/src/main/java/pt/up/fe/pangolin/eclipse/core/launching/VMArgsLaunchConfiguration.java
@@ -1,5 +1,6 @@
 package pt.up.fe.pangolin.eclipse.core.launching;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -210,6 +211,54 @@ public class VMArgsLaunchConfiguration implements ILaunchConfiguration {
 	@Override
 	public boolean isReadOnly() {
 		return delegate.isReadOnly();
+	}
+
+	@Override
+	public void delete(int arg0) throws CoreException {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public int getKind() throws CoreException {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public ILaunchConfiguration getPrototype() throws CoreException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Collection<ILaunchConfiguration> getPrototypeChildren() throws CoreException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Set<String> getPrototypeVisibleAttributes() throws CoreException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isAttributeModified(String arg0) throws CoreException {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isPrototype() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void setPrototypeAttributeVisibility(String arg0, boolean arg1) throws CoreException {
+		// TODO Auto-generated method stub
+		
 	}
 
 }

--- a/pangolin-eclipse-runtime/src/main/java/org/eclipse/jdt/internal/junit/runner/TestExecution.java
+++ b/pangolin-eclipse-runtime/src/main/java/org/eclipse/jdt/internal/junit/runner/TestExecution.java
@@ -23,7 +23,7 @@ public class TestExecution {
 
 	private IClassifiesThrowables fClassifier;
 
-	private ArrayList fStopListeners = new ArrayList();
+	private ArrayList<IStopListener> fStopListeners = new ArrayList<IStopListener>();
 
 	public TestExecution(IListensToTestExecutions listener,
 			IClassifiesThrowables classifier) {
@@ -45,7 +45,7 @@ public class TestExecution {
 
 	public void stop() {
 		fShouldStop = true;
-		for (Iterator iter = fStopListeners.iterator(); iter.hasNext();) {
+		for (Iterator<IStopListener> iter = fStopListeners.iterator(); iter.hasNext();) {
 			IStopListener listener = (IStopListener) iter.next();
 			listener.stop();
 		}

--- a/pangolin-eclipse-ui/META-INF/MANIFEST.MF
+++ b/pangolin-eclipse-ui/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Pangolin plugin UI
 Bundle-SymbolicName: pt.up.fe.pangolin.eclipse.ui;singleton:=true
 Bundle-Version: 0.0.1
 Bundle-Activator: pt.up.fe.pangolin.eclipse.ui.Activator
+Automatic-Module-Name: pt.up.fe.pangolin.eclipse.ui
 Require-Bundle: org.eclipse.ui,
  pt.up.fe.pangolin.eclipse.core;bundle-version="0.0.0",
  org.eclipse.debug.ui,

--- a/pangolin-eclipse-ui/META-INF/MANIFEST.MF
+++ b/pangolin-eclipse-ui/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Require-Bundle: org.eclipse.ui,
 Import-Package: org.eclipse.core.resources,
  org.eclipse.ui.ide,
  org.eclipse.ui.texteditor
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.version>0.0.1.SNAPSHOT</project.version>
-        <kepler-repo.url>http://download.eclipse.org/releases/kepler</kepler-repo.url>
-        <tycho-version>0.20.0</tycho-version>
+        <kepler-repo.url>http://download.eclipse.org/releases/2019-06</kepler-repo.url>
+        <tycho-version>1.4.0</tycho-version>
     </properties>
 
     <repositories>
@@ -32,8 +32,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This seems to be required as I am no longer able to run the plugin. 

Can you double check if the generated stubs in VMArgsLaunchConfiguration.java need extra work?